### PR TITLE
build: remove unnecessary codecov dependency

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests on CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.0.1
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==7.1.0
     # via codecov
 distlib==0.3.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -58,8 +58,6 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
 coverage[toml]==7.1.0
     # via
     #   -r requirements/ci.txt


### PR DESCRIPTION
**Description:** Context: https://about.codecov.io/blog/message-regarding-the-pypi-package/

Since codecov's GHA-based uploader doesn't depend on this package, this PR removes it.


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Commits are squashed