### PR TITLE
fix: remove tox-battery from requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,10 +7,8 @@
 asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
-    # via
-    #   oscrypto
-    #   snowflake-connector-python
-certifi==2023.7.22
+    # via snowflake-connector-python
+certifi==2023.11.17
     # via
     #   requests
     #   snowflake-connector-python
@@ -19,17 +17,17 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.3.1
+charset-normalizer==3.3.2
     # via
     #   requests
     #   snowflake-connector-python
 click==8.1.7
     # via edx-django-utils
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   pyopenssl
     #   snowflake-connector-python
-django==3.2.22
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -44,34 +42,32 @@ django-model-utils==4.3.1
     # via -r requirements/base.in
 django-waffle==4.0.0
     # via edx-django-utils
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via -r requirements/base.in
 edx-opaque-keys==2.5.1
     # via -r requirements/base.in
 filelock==3.13.1
     # via snowflake-connector-python
-idna==3.4
+idna==3.6
     # via
     #   requests
     #   snowflake-connector-python
 jsonfield==3.1.0
     # via -r requirements/base.in
-newrelic==9.1.1
+newrelic==9.3.0
     # via edx-django-utils
-oscrypto==1.3.0
-    # via snowflake-connector-python
 packaging==23.2
     # via snowflake-connector-python
-pbr==5.11.1
+pbr==6.0.0
     # via stevedore
 platformdirs==3.11.0
-    # via snowflake-connector-python
+    # via
+    #   -c requirements/constraints.txt
+    #   snowflake-connector-python
 psutil==5.9.6
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.19.0
-    # via snowflake-connector-python
 pyjwt==2.8.0
     # via snowflake-connector-python
 pymongo==3.13.0
@@ -88,7 +84,7 @@ requests==2.31.0
     # via
     #   -r requirements/base.in
     #   snowflake-connector-python
-snowflake-connector-python==3.3.1
+snowflake-connector-python==3.6.0
     # via -r requirements/base.in
 sortedcontainers==2.4.0
     # via snowflake-connector-python
@@ -98,7 +94,7 @@ stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via snowflake-connector-python
 typing-extensions==4.8.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -11,20 +17,23 @@ filelock==3.13.1
     #   tox
     #   virtualenv
 packaging==23.2
-    # via tox
+    # via
+    #   pyproject-api
+    #   tox
 platformdirs==3.11.0
-    # via virtualenv
+    # via
+    #   -c requirements/constraints.txt
+    #   tox
+    #   virtualenv
 pluggy==1.3.0
     # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
-    # via tox
-tox==3.28.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/ci.in
-virtualenv==20.24.6
+    #   pyproject-api
+    #   tox
+tox==4.11.4
+    # via -r requirements/ci.in
+virtualenv==20.25.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,6 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+# snowflake-connector-python requirest platformdirs<4.0.0
+platformdirs<4.0.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,4 +7,3 @@
 
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,7 +11,6 @@ asgiref==3.7.2
 asn1crypto==1.5.1
     # via
     #   -r requirements/quality.txt
-    #   oscrypto
     #   snowflake-connector-python
 astroid==3.0.1
     # via
@@ -22,7 +21,11 @@ build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2023.7.22
+cachetools==5.3.2
+    # via
+    #   -r requirements/ci.txt
+    #   tox
+certifi==2023.11.17
     # via
     #   -r requirements/quality.txt
     #   requests
@@ -34,8 +37,11 @@ cffi==1.16.0
     #   pynacl
     #   snowflake-connector-python
 chardet==5.2.0
-    # via diff-cover
-charset-normalizer==3.3.1
+    # via
+    #   -r requirements/ci.txt
+    #   diff-cover
+    #   tox
+charset-normalizer==3.3.2
     # via
     #   -r requirements/quality.txt
     #   requests
@@ -57,16 +63,21 @@ code-annotations==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 coverage[toml]==7.3.2
     # via
     #   -r requirements/quality.txt
+    #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/quality.txt
     #   pyopenssl
     #   snowflake-connector-python
-diff-cover==8.0.0
+diff-cover==8.0.1
     # via -r requirements/dev.in
 dill==0.3.7
     # via
@@ -76,7 +87,7 @@ distlib==0.3.7
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.22
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -100,7 +111,7 @@ docutils==0.20.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via -r requirements/quality.txt
 edx-i18n-tools==1.3.0
     # via -r requirements/dev.in
@@ -108,7 +119,7 @@ edx-lint==5.3.6
     # via -r requirements/quality.txt
 edx-opaque-keys==2.5.1
     # via -r requirements/quality.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -119,19 +130,19 @@ filelock==3.13.1
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/quality.txt
     #   requests
     #   snowflake-connector-python
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   build
     #   keyring
     #   twine
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -154,7 +165,7 @@ jinja2==3.1.2
     #   diff-cover
 jsonfield==3.1.0
     # via -r requirements/quality.txt
-keyring==24.2.0
+keyring==24.3.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -180,30 +191,27 @@ more-itertools==10.1.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-oscrypto==1.3.0
-    # via
-    #   -r requirements/quality.txt
-    #   snowflake-connector-python
 packaging==23.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   build
+    #   pyproject-api
     #   pytest
     #   snowflake-connector-python
     #   tox
-path==16.7.1
+path==16.9.0
     # via edx-i18n-tools
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
@@ -215,10 +223,12 @@ pkginfo==1.9.6
     #   twine
 platformdirs==3.11.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
     #   snowflake-connector-python
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
@@ -233,23 +243,15 @@ psutil==5.9.6
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-py==1.11.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox
 pycodestyle==2.11.1
     # via -r requirements/quality.txt
 pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
-pycryptodomex==3.19.0
-    # via
-    #   -r requirements/quality.txt
-    #   snowflake-connector-python
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   -r requirements/quality.txt
     #   diff-cover
@@ -291,6 +293,10 @@ pyopenssl==23.3.0
     # via
     #   -r requirements/quality.txt
     #   snowflake-connector-python
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
@@ -302,7 +308,7 @@ pytest==7.4.3
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/quality.txt
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/quality.txt
 python-slugify==8.0.1
     # via
@@ -336,21 +342,19 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==13.6.0
+rich==13.7.0
     # via
     #   -r requirements/quality.txt
     #   twine
 six==1.16.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-lint
-    #   tox
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-snowflake-connector-python==3.3.1
+snowflake-connector-python==3.6.0
     # via -r requirements/quality.txt
 sortedcontainers==2.4.0
     # via
@@ -379,21 +383,17 @@ tomli==2.0.1
     #   coverage
     #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   snowflake-connector-python
-tox==3.28.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/dev.in
+tox==4.11.4
+    # via -r requirements/ci.txt
 twine==4.0.2
     # via -r requirements/quality.txt
 typing-extensions==4.8.0
@@ -411,11 +411,11 @@ urllib3==1.26.18
     #   requests
     #   snowflake-connector-python
     #   twine
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.41.3
+wheel==0.42.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,13 +13,12 @@ asgiref==3.7.2
 asn1crypto==1.5.1
     # via
     #   -r requirements/test.txt
-    #   oscrypto
     #   snowflake-connector-python
 babel==2.13.1
     # via sphinx
 build==1.0.3
     # via -r requirements/doc.in
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   requests
@@ -30,7 +29,7 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.3.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -45,13 +44,14 @@ code-annotations==1.5.0
 coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   pyopenssl
     #   snowflake-connector-python
-django==3.2.22
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -78,13 +78,13 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via -r requirements/test.txt
 edx-opaque-keys==2.5.1
     # via -r requirements/test.txt
 edx-sphinx-theme==3.1.0
     # via -r requirements/doc.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -92,20 +92,20 @@ filelock==3.13.1
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
     #   snowflake-connector-python
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   build
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via keyring
 iniconfig==2.0.0
     # via
@@ -120,7 +120,7 @@ jinja2==3.1.2
     #   sphinx
 jsonfield==3.1.0
     # via -r requirements/test.txt
-keyring==24.2.0
+keyring==24.3.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
@@ -132,16 +132,12 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.1.0
     # via jaraco-classes
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
-oscrypto==1.3.0
-    # via
-    #   -r requirements/test.txt
-    #   snowflake-connector-python
 packaging==23.2
     # via
     #   -r requirements/test.txt
@@ -149,7 +145,7 @@ packaging==23.2
     #   pytest
     #   snowflake-connector-python
     #   sphinx
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -157,6 +153,7 @@ pkginfo==1.9.6
     # via twine
 platformdirs==3.11.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   snowflake-connector-python
 pluggy==1.3.0
@@ -171,11 +168,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.19.0
-    # via
-    #   -r requirements/test.txt
-    #   snowflake-connector-python
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   doc8
     #   readme-renderer
@@ -206,7 +199,7 @@ pytest==7.4.3
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.txt
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/test.txt
 python-slugify==8.0.1
     # via
@@ -237,13 +230,13 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.6.0
+rich==13.7.0
     # via twine
 six==1.16.0
     # via edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.3.1
+snowflake-connector-python==3.6.0
     # via -r requirements/test.txt
 sortedcontainers==2.4.0
     # via
@@ -288,7 +281,7 @@ tomli==2.0.1
     #   doc8
     #   pyproject-hooks
     #   pytest
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via build
 packaging==23.2
     # via build
@@ -21,7 +21,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -11,13 +11,12 @@ asgiref==3.7.2
 asn1crypto==1.5.1
     # via
     #   -r requirements/test.txt
-    #   oscrypto
     #   snowflake-connector-python
 astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   requests
@@ -28,7 +27,7 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.3.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
     #   requests
@@ -49,15 +48,16 @@ code-annotations==1.5.0
 coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
+    #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   pyopenssl
     #   snowflake-connector-python
 dill==0.3.7
     # via pylint
-django==3.2.22
+django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -78,13 +78,13 @@ django-waffle==4.0.0
     #   edx-django-utils
 docutils==0.20.1
     # via readme-renderer
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via -r requirements/test.txt
 edx-lint==5.3.6
     # via -r requirements/quality.in
 edx-opaque-keys==2.5.1
     # via -r requirements/test.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -92,16 +92,16 @@ filelock==3.13.1
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
     #   snowflake-connector-python
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   keyring
     #   twine
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via keyring
 iniconfig==2.0.0
     # via
@@ -119,7 +119,7 @@ jinja2==3.1.2
     #   code-annotations
 jsonfield==3.1.0
     # via -r requirements/test.txt
-keyring==24.2.0
+keyring==24.3.0
     # via twine
 markdown-it-py==3.0.0
     # via rich
@@ -133,22 +133,18 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.1.0
     # via jaraco-classes
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
-oscrypto==1.3.0
-    # via
-    #   -r requirements/test.txt
-    #   snowflake-connector-python
 packaging==23.2
     # via
     #   -r requirements/test.txt
     #   pytest
     #   snowflake-connector-python
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -156,6 +152,7 @@ pkginfo==1.9.6
     # via twine
 platformdirs==3.11.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   pylint
     #   snowflake-connector-python
@@ -173,13 +170,9 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.19.0
-    # via
-    #   -r requirements/test.txt
-    #   snowflake-connector-python
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   readme-renderer
     #   rich
@@ -220,7 +213,7 @@ pytest==7.4.3
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.txt
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/test.txt
 python-slugify==8.0.1
     # via
@@ -247,13 +240,13 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.6.0
+rich==13.7.0
     # via twine
 six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-snowflake-connector-python==3.3.1
+snowflake-connector-python==3.6.0
     # via -r requirements/test.txt
 sortedcontainers==2.4.0
     # via
@@ -279,7 +272,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,9 +11,8 @@ asgiref==3.7.2
 asn1crypto==1.5.1
     # via
     #   -r requirements/base.txt
-    #   oscrypto
     #   snowflake-connector-python
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/base.txt
     #   requests
@@ -24,7 +23,7 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.3.1
+charset-normalizer==3.3.2
     # via
     #   -r requirements/base.txt
     #   requests
@@ -37,8 +36,10 @@ click==8.1.7
 code-annotations==1.5.0
     # via -r requirements/test.in
 coverage[toml]==7.3.2
-    # via pytest-cov
-cryptography==41.0.5
+    # via
+    #   coverage
+    #   pytest-cov
+cryptography==41.0.7
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -61,17 +62,17 @@ django-waffle==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-edx-django-utils==5.7.0
+edx-django-utils==5.9.0
     # via -r requirements/base.txt
 edx-opaque-keys==2.5.1
     # via -r requirements/base.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 filelock==3.13.1
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
@@ -84,25 +85,22 @@ jsonfield==3.1.0
     # via -r requirements/base.txt
 markupsafe==2.1.3
     # via jinja2
-newrelic==9.1.1
+newrelic==9.3.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-oscrypto==1.3.0
-    # via
-    #   -r requirements/base.txt
-    #   snowflake-connector-python
 packaging==23.2
     # via
     #   -r requirements/base.txt
     #   pytest
     #   snowflake-connector-python
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
 platformdirs==3.11.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   snowflake-connector-python
 pluggy==1.3.0
@@ -115,10 +113,6 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.19.0
-    # via
-    #   -r requirements/base.txt
-    #   snowflake-connector-python
 pyjwt==2.8.0
     # via
     #   -r requirements/base.txt
@@ -141,7 +135,7 @@ pytest==7.4.3
     #   pytest-django
 pytest-cov==4.1.0
     # via -r requirements/test.in
-pytest-django==4.6.0
+pytest-django==4.7.0
     # via -r requirements/test.in
 python-slugify==8.0.1
     # via code-annotations
@@ -156,7 +150,7 @@ requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
-snowflake-connector-python==3.3.1
+snowflake-connector-python==3.6.0
     # via -r requirements/base.txt
 sortedcontainers==2.4.0
     # via
@@ -178,7 +172,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
     pytest {posargs}
 
 [testenv:quality]
-whitelist_externals =
+allowlist_externals =
     make
     rm
     touch
@@ -66,4 +66,3 @@ deps =
     -r{toxinidir}/requirements/test.txt
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage
-


### PR DESCRIPTION
## Description
- Removed `tox-battery` from requirements and updated `tox` to `v4`.